### PR TITLE
Support CSV files, faster CSV/TSV parsing

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,6 +6,7 @@
                           :exclusions [org.slf4j/jul-to-slf4j org.slf4j/slf4j-nop]}
         com.cognitect.aws/api       {:mvn/version "0.8.505"}
         com.cognitect.aws/s3        {:mvn/version "811.2.858.0"}
+        com.cnuernber/charred {:mvn/version "1.033"}
         org.clojure/data.csv {:mvn/version "1.0.0"}
         clj-http/clj-http {:mvn/version "3.10.0"}
         org.clojure/core.async {:mvn/version "1.6.681"}

--- a/src/com/vendekagonlabs/unify/import/engine.clj
+++ b/src/com/vendekagonlabs/unify/import/engine.clj
@@ -13,7 +13,7 @@
 ;; limitations under the License.
 
 (ns com.vendekagonlabs.unify.import.engine
-  (:require [clojure.data.csv :as csv]
+  (:require [charred.api :as csv]
             [clojure.edn :as edn]
             [clojure.java.io :as jio]
             [clojure.set :as set]

--- a/src/com/vendekagonlabs/unify/import/engine/parse/matrix_file.clj
+++ b/src/com/vendekagonlabs/unify/import/engine/parse/matrix_file.clj
@@ -12,7 +12,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns com.vendekagonlabs.unify.import.engine.parse.matrix-file
-  (:require [clojure.data.csv :as csv]
+  (:require [charred.api :as csv]
             [clojure.spec-alpha2 :as s]
             [clojure.java.io :as jio]
             [com.vendekagonlabs.unify.import.engine.parse.data :as parse.data]))

--- a/test/resources/systems/candel/template-dataset/config.edn
+++ b/test/resources/systems/candel/template-dataset/config.edn
@@ -242,7 +242,7 @@
                                                    ; The therapy entity links subjects to treatment-regimens (see below) which are things like arms of clinical trials, which many subjects are on.
                                                    ; The wick package contains helper functions to generate all this data for the simple case in which each subject has only a single therapy
                                                    :therapies        {; This input file will have one line per subject-therapy combination
-                                                                      :unify/input-tsv-file  "processed/rizvi-therapies.txt"
+                                                                      :unify/input-csv-file  "processed/rizvi-therapies.txt"
                                                                       ; The treatment-regimen attribute points to treatment regimens, which have been separately specified in the dataset (see below)
                                                                       ; This attribute needs to contain values that correspond to the :treatment-regimen/name fields
                                                                       :treatment-regimen "regimen"

--- a/test/resources/systems/candel/template-dataset/processed/rizvi-therapies.txt
+++ b/test/resources/systems/candel/template-dataset/processed/rizvi-therapies.txt
@@ -1,35 +1,35 @@
-subject.id	line	regimen
-SA9755	2	Pembrolizumab-3wk
-HE3202	4	Pembrolizumab-3wk
-TU0428	1	Pembrolizumab-3wk
-Y2087	6	Pembrolizumab-3wk
-RI1933	2	Pembrolizumab-3wk
-M4945	4	Pembrolizumab-2wk
-ZA6505	7	Pembrolizumab-3wk
-CU9061	2	Pembrolizumab-3wk
-CA9903	4	Pembrolizumab-3wk
-KA3947	1	Pembrolizumab-3wk
-SC0899	1	Pembrolizumab-3wk
-MA7027	2	Pembrolizumab-2wk
-FR9547	2	Pembrolizumab-3wk
-AL4602	1	Pembrolizumab-3wk
-DI6359	7	Pembrolizumab-3wk
-ZA6965	2	Pembrolizumab-3wk
-RH090935	1	Pembrolizumab-3wk
-SB010944	3	Pembrolizumab-3wk
-JB112852	6	Pembrolizumab-2wk
-SC6470	1	Pembrolizumab-2wk
-SR070761	5	Pembrolizumab-2wk
-GR4788	1	Pembrolizumab-2wk
-BL3403	2	Pembrolizumab-2wk
-DM123062	7	Pembrolizumab-2wk
-WA7899	3	Pembrolizumab-3wk
-R7495	3	Pembrolizumab-3wk
-LO3793	3	Pembrolizumab-3wk
-RO3338	2	Pembrolizumab-3wk
-LO5004	1	Pembrolizumab-2wk
-GR0134	1	Pembrolizumab-3wk
-NI9507	2	Pembrolizumab-3wk
-AU5884	3	Pembrolizumab-2wk
-VA1330	2	Pembrolizumab-3wk
-VA7859	2	Pembrolizumab-3wk
+subject.id,line,regimen
+SA9755,2,Pembrolizumab-3wk
+HE3202,4,Pembrolizumab-3wk
+TU0428,1,Pembrolizumab-3wk
+Y2087,6,Pembrolizumab-3wk
+RI1933,2,Pembrolizumab-3wk
+M4945,4,Pembrolizumab-2wk
+ZA6505,7,Pembrolizumab-3wk
+CU9061,2,Pembrolizumab-3wk
+CA9903,4,Pembrolizumab-3wk
+KA3947,1,Pembrolizumab-3wk
+SC0899,1,Pembrolizumab-3wk
+MA7027,2,Pembrolizumab-2wk
+FR9547,2,Pembrolizumab-3wk
+AL4602,1,Pembrolizumab-3wk
+DI6359,7,Pembrolizumab-3wk
+ZA6965,2,Pembrolizumab-3wk
+RH090935,1,Pembrolizumab-3wk
+SB010944,3,Pembrolizumab-3wk
+JB112852,6,Pembrolizumab-2wk
+SC6470,1,Pembrolizumab-2wk
+SR070761,5,Pembrolizumab-2wk
+GR4788,1,Pembrolizumab-2wk
+BL3403,2,Pembrolizumab-2wk
+DM123062,7,Pembrolizumab-2wk
+WA7899,3,Pembrolizumab-3wk
+R7495,3,Pembrolizumab-3wk
+LO3793,3,Pembrolizumab-3wk
+RO3338,2,Pembrolizumab-3wk
+LO5004,1,Pembrolizumab-2wk
+GR0134,1,Pembrolizumab-3wk
+NI9507,2,Pembrolizumab-3wk
+AU5884,3,Pembrolizumab-2wk
+VA1330,2,Pembrolizumab-3wk
+VA7859,2,Pembrolizumab-3wk


### PR DESCRIPTION
This adds support for reading CSV files, and brings in charred as a drop in replacement for data.csv for faster csv/tsv reading in performance critical paths.

There's some fiddly branching in the CSV vs TSV file handling, but waiting to rewrite this until after:

1. need to support a third file format (rule of three blah blah blah)
2. parse config cleaned up
3. contextualize removed from parse config

This resolves #12 