### PR TITLE
Local ops using docker compose

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -30,7 +30,8 @@
 
  :paths ["src" "resources"]
  :aliases {:dev {:extra-paths ["dev" "test"]
-                 :extra-deps {techascent/tech.ml.dataset {:mvn/version "7.007"}}}
+                 :extra-deps {techascent/tech.ml.dataset {:mvn/version "7.007"}
+                              org.postgresql/postgresql {:mvn/version "42.7.1"}}}
            :repl-server {:exec-fn clojure.core.server/start-server
                          :extra-paths ["dev" "test"]
                          :extra-deps {techascent/tech.ml.dataset {:mvn/version "7.007"}} 

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -12,7 +12,8 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns user
-  (:require [datomic.api :as d]
+  (:require [com.vendekagonlabs.unify.db.config :as config]
+            [datomic.api :as d]
             [clojure.data.csv :as csv]
             [clojure.data.json :as json]
             [clojure.java.io :as io]
@@ -37,7 +38,7 @@
 
 
 (defn unify [& args]
-  (with-redefs [backend/db-base-uri
+  (with-redefs [config/base-uri
                 (fn [] "datomic:mem://")
                 err/exit
                 (fn [code msg]

--- a/ops/local/README.md
+++ b/ops/local/README.md
@@ -1,0 +1,26 @@
+# Local Ops
+
+The local ops system uses docker-compose to stand up a basic Datomic postgres
+backed service.
+
+## Required Setup
+
+You will need to download a recent version of [Docker](https://docs.docker.com/get-docker/)
+for your platform, which should have `docker-compose` bundled with it.
+
+## Starting and Stopping the local dev system
+
+You can start or stop the system with the wrapping scripts in `util/`
+
+```
+util/start-local-system
+util/stop-local-system
+```
+
+## Notes
+
+This work was derived from the example
+[here](https://github.com/galuque/datomic-compose),
+though it has been substantially simplified. It also uses a PostGIS container,
+for planned future support for GIS/geometry/shape information in a Unify blob
+format.

--- a/ops/local/docker-compose.yml
+++ b/ops/local/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     networks:
       - datomic-network
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "datomic"]
+      test: ["CMD", "pg_isready", "-U", "unify"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/ops/local/docker-compose.yml
+++ b/ops/local/docker-compose.yml
@@ -1,0 +1,58 @@
+version: '3.9'
+services:
+  postgres:
+    image: postgis/postgis:16-3.4
+    environment:
+      POSTGRES_USER: unify
+      POSTGRES_PASSWORD: unify
+      POSTGRES_DB: unify
+    ports:
+      - 5432:5432
+    volumes:
+      - ./files/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - datomic-storage-data:/var/lib/postgresql/data
+    networks:
+      - datomic-network
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "datomic"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: always
+
+
+  transactor:
+    image: datomic:1.0.7075-java17 
+    build: 
+      context: ./images/transactor/
+      dockerfile: Dockerfile
+    ports:
+      - 4334:4334
+    volumes:
+      - datomic-transactor-logs:/opt/datomic/logs
+    configs:
+      - transactor.properties
+    networks:
+      - datomic-network
+    healthcheck:
+      test: ["CMD", "curl", "http://localhost:9999/health"]
+      interval: 30s
+      timeout: 30s
+      retries: 5
+      start_period: 10s
+    restart: always
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+configs:
+  transactor.properties:
+    file: ./files/sql-transactor.properties
+
+networks:
+  datomic-network:
+    driver: bridge
+
+volumes:
+  datomic-storage-data:
+  datomic-transactor-logs:

--- a/ops/local/files/init.sql
+++ b/ops/local/files/init.sql
@@ -1,0 +1,15 @@
+CREATE TABLE datomic_kvs
+(
+ id text NOT NULL,
+ rev integer,
+ map text,
+ val bytea,
+ CONSTRAINT pk_id PRIMARY KEY (id )
+)
+WITH (
+ OIDS=FALSE
+);
+ALTER TABLE datomic_kvs
+ OWNER TO unify;
+GRANT ALL ON TABLE datomic_kvs TO unify;
+GRANT ALL ON TABLE datomic_kvs TO public;

--- a/ops/local/files/init.sql
+++ b/ops/local/files/init.sql
@@ -1,3 +1,4 @@
+CREATE ROLE unify LOGIN PASSWORD 'unify';
 CREATE TABLE datomic_kvs
 (
  id text NOT NULL,

--- a/ops/local/files/sql-transactor.properties
+++ b/ops/local/files/sql-transactor.properties
@@ -1,0 +1,14 @@
+protocol=sql
+host=0.0.0.0
+alt-host=transactor
+port=4334
+sql-url=jdbc:postgresql://postgres:5432/unify
+sql-user=unify
+sql-password=unify
+sql-driver-class=org.postgresql.Driver
+memory-index-threshold=32m
+memory-index-max=256m
+object-cache-max=128m
+memcached=memcached:11211
+ping-host=0.0.0.0
+ping-port=9999

--- a/ops/local/files/sql-transactor.properties
+++ b/ops/local/files/sql-transactor.properties
@@ -1,6 +1,6 @@
 protocol=sql
 host=0.0.0.0
-alt-host=transactor
+alt-host=localhost
 port=4334
 sql-url=jdbc:postgresql://postgres:5432/unify
 sql-user=unify
@@ -9,6 +9,5 @@ sql-driver-class=org.postgresql.Driver
 memory-index-threshold=32m
 memory-index-max=256m
 object-cache-max=128m
-memcached=memcached:11211
 ping-host=0.0.0.0
 ping-port=9999

--- a/ops/local/images/transactor/Dockerfile
+++ b/ops/local/images/transactor/Dockerfile
@@ -1,0 +1,15 @@
+FROM amazoncorretto:17
+
+RUN yum install -y unzip && yum clean all
+
+ARG DATOMIC_VERSION=1.0.7075
+
+WORKDIR /opt/
+RUN curl -O https://datomic-pro-downloads.s3.amazonaws.com/${DATOMIC_VERSION}/datomic-pro-${DATOMIC_VERSION}.zip
+RUN unzip datomic-pro-${DATOMIC_VERSION}.zip
+RUN rm datomic-pro-${DATOMIC_VERSION}.zip
+RUN mv datomic-pro-${DATOMIC_VERSION} datomic
+
+ENV JVM_OPTS="-Xmx1g -Xms1g"
+
+ENTRYPOINT /opt/datomic/bin/transactor ${JVM_OPTS} /transactor.properties

--- a/unify-local
+++ b/unify-local
@@ -1,0 +1,2 @@
+#!/bin/bash
+UNIFY_BASE_URI="datomic:sql://?jdbc:postgresql://localhost:5432/unify?user=unify&password=unify" clojure -Mdev -m com.vendekagonlabs.unify.cli $* 

--- a/util/start-local-system
+++ b/util/start-local-system
@@ -1,0 +1,3 @@
+#!/bin/bash
+pushd ops/local
+docker-compose up

--- a/util/stop-local-system
+++ b/util/stop-local-system
@@ -1,0 +1,3 @@
+#!/bin/bash
+pushd ops/local
+docker-compose down


### PR DESCRIPTION
That allows single script start and stop of a local Datomic dev system, reducing the required steps a user needs to take to start working with Datomic with Unify.