### PR TITLE
Local ops now stand up a schema browser and JSON query service

### DIFF
--- a/ops/local/README.md
+++ b/ops/local/README.md
@@ -8,6 +8,9 @@ backed service.
 You will need to download a recent version of [Docker](https://docs.docker.com/get-docker/)
 for your platform, which should have `docker-compose` bundled with it.
 
+For local development and running Unify outside of compose, you might want to
+alias `transactor` to 127.0.0.1 in your `/etc/hosts` file.
+
 ## Starting and Stopping the local dev system
 
 You can start or stop the system with the wrapping scripts in `util/`

--- a/ops/local/docker-compose.yml
+++ b/ops/local/docker-compose.yml
@@ -45,6 +45,28 @@ services:
       postgres:
         condition: service_healthy
 
+  query-service:
+    image: vendekagonlabs/datomic-query-service
+    environment:
+      DATOMIC_BASE_URI: "datomic:dev://localhost:4334/"
+      BEARER_TOKEN: "dev"
+    healthcheck:
+      test: ["CMD", "curl", "http://localhost:8988/health"]
+      interval: 30s
+      timeout: 30s
+      retries: 5
+      start_period: 10s
+    restart: always
+    networks:
+      - datomic-network
+    ports:
+      - 8988:80
+    depends_on:
+      postgres:
+        condition: service_healthy
+      transactor:
+        condition: service_healthy
+
 configs:
   transactor.properties:
     file: ./files/sql-transactor.properties

--- a/ops/local/docker-compose.yml
+++ b/ops/local/docker-compose.yml
@@ -48,8 +48,7 @@ services:
   query-service:
     image: vendekagonlabs/datomic-query-service
     environment:
-      # TODO: change this to postgres URL after fixing base URI code path
-      DATOMIC_BASE_URI: "datomic:dev://transactor:4334/"
+      BASE_DATOMIC_URI: datomic:sql://?jdbc:postgresql://postgres:5432/unify?user=unify&password=unify
       BEARER_TOKEN: "dev"
     healthcheck:
       test: ["CMD", "curl", "http://localhost:80/health"]

--- a/ops/local/docker-compose.yml
+++ b/ops/local/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       DATOMIC_BASE_URI: "datomic:dev://localhost:4334/"
       BEARER_TOKEN: "dev"
     healthcheck:
-      test: ["CMD", "curl", "http://localhost:8988/health"]
+      test: ["CMD", "curl", "http://localhost:80/health"]
       interval: 30s
       timeout: 30s
       retries: 5
@@ -67,6 +67,30 @@ services:
       transactor:
         condition: service_healthy
 
+  schema-browser:
+    image: vendekagonlabs/unify-schema-browser
+    networks:
+      - datomic-network
+    ports:
+      - 8899:8899 
+    volumes:
+      - ./unify-schema-dir:/schema/unify
+    environment:
+      UNIFY_SCHEMA_DIRECTORY: /schema/unify/
+    healthcheck:
+      test: ["CMD", "curl", "http://localhost:8899/health"]
+      interval: 30s
+      timeout: 30s
+      retries: 5
+      start_period: 10s
+    restart: always
+    depends_on:
+      postgres:
+        condition: service_healthy
+      transactor:
+        condition: service_healthy
+
+
 configs:
   transactor.properties:
     file: ./files/sql-transactor.properties
@@ -78,3 +102,4 @@ networks:
 volumes:
   datomic-storage-data:
   datomic-transactor-logs:
+  unify-schema-dir:

--- a/ops/local/docker-compose.yml
+++ b/ops/local/docker-compose.yml
@@ -48,7 +48,8 @@ services:
   query-service:
     image: vendekagonlabs/datomic-query-service
     environment:
-      DATOMIC_BASE_URI: "datomic:dev://localhost:4334/"
+      # TODO: change this to postgres URL after fixing base URI code path
+      DATOMIC_BASE_URI: "datomic:dev://transactor:4334/"
       BEARER_TOKEN: "dev"
     healthcheck:
       test: ["CMD", "curl", "http://localhost:80/health"]
@@ -73,10 +74,8 @@ services:
       - datomic-network
     ports:
       - 8899:8899 
-    volumes:
-      - ../../test/resources/systems/candel/template-dataset/schema:/schema/unify
     environment:
-      UNIFY_SCHEMA_DIRECTORY: /schema/unify/
+      DATOMIC_URI: datomic:sql://unify-example?jdbc:postgresql://postgres:5432/unify?user=unify&password=unify
     healthcheck:
       test: ["CMD", "curl", "http://localhost:8899/health"]
       interval: 30s

--- a/ops/local/docker-compose.yml
+++ b/ops/local/docker-compose.yml
@@ -73,9 +73,10 @@ services:
     networks:
       - datomic-network
     ports:
-      - 8899:8899 
+      - 8899:80 
     environment:
       DATOMIC_URI: datomic:sql://unify-example?jdbc:postgresql://postgres:5432/unify?user=unify&password=unify
+      SERVICE_PORT: 80
     healthcheck:
       test: ["CMD", "curl", "http://localhost:8899/health"]
       interval: 30s

--- a/ops/local/docker-compose.yml
+++ b/ops/local/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     ports:
       - 8899:8899 
     volumes:
-      - ./unify-schema-dir:/schema/unify
+      - ../../test/resources/systems/candel/template-dataset/schema:/schema/unify
     environment:
       UNIFY_SCHEMA_DIRECTORY: /schema/unify/
     healthcheck:
@@ -102,4 +102,3 @@ networks:
 volumes:
   datomic-storage-data:
   datomic-transactor-logs:
-  unify-schema-dir:

--- a/ops/local/files/sql-transactor.properties
+++ b/ops/local/files/sql-transactor.properties
@@ -1,6 +1,6 @@
 protocol=sql
 host=0.0.0.0
-alt-host=localhost
+alt-host=transactor
 port=4334
 sql-url=jdbc:postgresql://postgres:5432/unify
 sql-user=unify

--- a/util/local-test-query.py
+++ b/util/local-test-query.py
@@ -17,8 +17,8 @@ if len(sys.argv) > 1:
 # Otherwise, minimal default query counts number of patients in the database.
 else:
     print("Using default query")
-    q = {":find": [["count", "?m"]],
-         ":where": [["?m", ":measurement/gene-product"]]}
+    q = {":find": [["count", "?g"]],
+         ":where": [["?g", ":gene/hgnc-symbol"]]}
     req_body = {"query": q,
                 "timeout": 30000}
 

--- a/util/local-test-query.py
+++ b/util/local-test-query.py
@@ -1,0 +1,58 @@
+import os
+import gzip as gz
+import sys
+import json
+
+# pip install requests
+import requests
+
+# A json file containing a query map nested in a request map can
+# be passed as the first argument to the script.:
+# {"query": {":find" ...}}
+if len(sys.argv) > 1:
+    with open(sys.argv[1], 'r') as f:
+        req_body = json.load(f)
+    q = req_body["query"]
+
+# Otherwise, minimal default query counts number of patients in the database.
+else:
+    print("Using default query")
+    q = {":find": [["count", "?m"]],
+         ":where": [["?m", ":measurement/gene-product"]]}
+    req_body = {"query": q,
+                "timeout": 30000}
+
+# parameters needed to issue the query request (POST) 
+endpoint = os.getenv('QUERY_SERVICE_ENDPOINT') or \
+           "http://localhost:8988/query/unify-example"
+bearer_token = os.getenv('BEARER_TOKEN') or "dev"
+headers = {
+        "Authorization": f"Bearer {bearer_token}",
+        "Accept": f"application/json",  # application/json returns un-cached json
+        #"Accept": f"text/plain"  # text/plain returns presigned s3 url
+}
+print("Querying querl URL:", endpoint)
+print("With query:\n")
+print(json.dumps(q, indent=1))
+
+resp = requests.post(endpoint, json.dumps(req_body), headers=headers,
+                     )
+print("Received response, downloading and unzipping.")
+
+if resp.status_code == 200:
+    print(resp.content)
+    if resp.headers['content-type'] == 'text/plain':
+        resp2 = requests.get(resp.content)
+        body = json.loads(gz.decompress(resp2.content))
+    else:
+        body = json.loads(resp.content)
+    print(body['query_result'])
+    print(f"Basis T of query results: {body['basis_t']}")
+else:
+    print("Encountered an error.")
+    print(resp.status_code)
+    try:
+        print(resp.text)
+    except:
+        print("Failed to decode response body.")
+


### PR DESCRIPTION
This resolves #16 

Now when you stand up a local system with:

`ops/start-local-system`

It stands up a schema browser which can be accessed at:

`http://localhost:8899/schema/1.3.1/index.html`

for the example CANDEL schema, as well as a query service which can be queried via POST with:

`http://localhost:8889/db-name/query`

see `util/local-test-query.py` for an example in Python.