### PR TITLE
New schema browser container updates

### DIFF
--- a/ops/local/docker-compose.yml
+++ b/ops/local/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     ports:
       - 8899:80 
     environment:
-      DATOMIC_URI: datomic:sql://unify-example?jdbc:postgresql://postgres:5432/unify?user=unify&password=unify
+      BASE_DATOMIC_URI: datomic:sql://?jdbc:postgresql://postgres:5432/unify?user=unify&password=unify
       SERVICE_PORT: 80
     healthcheck:
       test: ["CMD", "curl", "http://localhost:8899/health"]

--- a/util/generate-schema-docs
+++ b/util/generate-schema-docs
@@ -1,0 +1,10 @@
+#!/bin/bash
+# one arg: name of database in local Unify system.
+echo "Generating schema for $1 using local Unify system."
+echo "NOTE: this script will fail if you have not started a local Unify system,"
+echo "eg. with: util/start-local-system"
+echo
+
+RESP=$(curl -s -X post http://localhost:8899/render/$1)
+echo "Schema docs generated! Navigate to: http://localhost:8899/${RESP:25}"
+


### PR DESCRIPTION
New env and a convenience `util/` script for generating new schema docs on demand, instead of just as schema browser container startup.