### PR TITLE
Simple backup and restore for local system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ datomic-config.edn
 test/resources/perf-benchmark
 .Rproj.user
 *.Rproj
+.datomic

--- a/src/com/vendekagonlabs/unify/cli.clj
+++ b/src/com/vendekagonlabs/unify/cli.clj
@@ -348,6 +348,7 @@
   (println unify-ascii)
   (try
     (println "version:" (release/version))
+    (println "--------------------------------------")
     (let [arg-map (validate-args args)
           {:keys [exit-message ok?]} arg-map]
       (if exit-message
@@ -357,6 +358,7 @@
               task-args (merge parsed options)
               task-fn (get tasks task)
               task-results (task-fn task-args)]
+          (println "--------------------------------------")
           (println "Took" (elapsed start (Date.)) "seconds")
           (if (:errors task-results)
             (exit 1 (str "Task: " task " failed "))

--- a/util/backup
+++ b/util/backup
@@ -1,0 +1,12 @@
+#!/bin/bash
+if [ -z "$1" ] || [ -z "$2" ]; then
+    echo "Must provide two positional arguments:"
+    echo "1. database name that already exists in the Unify local system"
+    echo "2. database backup URI to backup to (e.g. file:/// or s3:// location)"
+    exit 1
+fi
+
+util/helpers/ensure-datomic
+pushd .datomic/datomic-pro-*
+bin/datomic -Xmx4g -Xms4g backup-db "datomic:sql://$1?jdbc:postgresql://localhost:5432/unify?user=unify&password=unify" $2
+

--- a/util/helpers/ensure-datomic
+++ b/util/helpers/ensure-datomic
@@ -1,0 +1,11 @@
+#!/bin/bash
+if [ -d /.datomic ]; then
+  echo "Directory exists."
+  exit 0
+fi
+mkdir .datomic
+pushd .datomic
+wget -O datomic.zip https://datomic-pro-downloads.s3.amazonaws.com/1.0.7075/datomic-pro-1.0.7075.zip
+unzip datomic.zip
+rm datomic.zip
+popd

--- a/util/helpers/ensure-datomic
+++ b/util/helpers/ensure-datomic
@@ -1,9 +1,9 @@
 #!/bin/bash
-if [ -d /.datomic ]; then
-  echo "Detected previously cached Datomic at ./datomic, skipping download."
+if [ -d .datomic ]; then
+  echo "Detected previously cached Datomic at .datomic, skipping download."
   exit 0
 fi
-echo "No previously cached Datomic detected at ./datomic, downloading."
+echo "No previously cached Datomic detected at .datomic, downloading."
 mkdir .datomic
 pushd .datomic
 wget -O datomic.zip https://datomic-pro-downloads.s3.amazonaws.com/1.0.7075/datomic-pro-1.0.7075.zip

--- a/util/helpers/ensure-datomic
+++ b/util/helpers/ensure-datomic
@@ -1,8 +1,9 @@
 #!/bin/bash
 if [ -d /.datomic ]; then
-  echo "Directory exists."
+  echo "Detected previously cached Datomic at ./datomic, skipping download."
   exit 0
 fi
+echo "No previously cached Datomic detected at ./datomic, downloading."
 mkdir .datomic
 pushd .datomic
 wget -O datomic.zip https://datomic-pro-downloads.s3.amazonaws.com/1.0.7075/datomic-pro-1.0.7075.zip

--- a/util/restore
+++ b/util/restore
@@ -1,0 +1,12 @@
+#!/bin/bash
+if [ -z "$1" ] || [ -z "$2" ]; then
+    echo "Must provide two positional arguments:"
+    echo "1. database backup URI to restore from"
+    echo "2. database name under which it will be restored into the local Unify system."
+    exit 1
+fi
+
+util/helpers/ensure-datomic
+pushd .datomic/datomic-pro-*
+bin/datomic -Xmx4g -Xms4g restore-db $1 "datomic:sql://$2?jdbc:postgresql://localhost:5432/unify?user=unify&password=unify"
+


### PR DESCRIPTION
Util scripts that wrap the process of downloading a local Datomic directory and caching it in the Unify repo directory, then using it for backup and restore.

Simpler solution that resolves #17 