### PR TITLE
Generic matrix backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ test/resources/perf-benchmark
 .Rproj.user
 *.Rproj
 .datomic
+.unify

--- a/src/com/vendekagonlabs/unify/db/matrix.clj
+++ b/src/com/vendekagonlabs/unify/db/matrix.clj
@@ -41,8 +41,8 @@
         _ (io/make-parents (str matrix-write-dir "/---"))
         matrix-files (file-conventions/matrix-filenames working-dir)]
     (doseq [matrix-file matrix-files]
-      (let [src-path (file-conventions/in-matrix-dir working-dir matrix-file)
-            dest-path (str matrix-write-dir matrix-file)]
+      (let [src-path (io/file (file-conventions/in-matrix-dir working-dir matrix-file))
+            dest-path (io/file matrix-write-dir matrix-file)]
         (io/copy src-path dest-path)))
     true))
 

--- a/unify-local
+++ b/unify-local
@@ -1,2 +1,7 @@
 #!/bin/bash
-UNIFY_BASE_URI="datomic:sql://?jdbc:postgresql://localhost:5432/unify?user=unify&password=unify" clojure -Mdev -m com.vendekagonlabs.unify.cli $* 
+base_uri="datomic:sql://?jdbc:postgresql://localhost:5432/unify?user=unify&password=unify"
+matrix_backend="file"
+matrix_dir=".unify/matrix-files"
+
+UNIFY_BASE_URI=$base_uri UNIFY_MATRIX_BACKEND=$matrix_backend UNIFY_MATRIX_DIR=$matrix_dir clojure -Mdev -m com.vendekagonlabs.unify.cli $*
+


### PR DESCRIPTION
Sanity check of generic file handling path for matrices with a bug fix. Followed by config modifications to unify local script so that matrix files get written to a standard location.

Due to other recent simplifications, this resolves #25 