### PR TITLE
Remove schema-dir argument from transact

### DIFF
--- a/src/com/vendekagonlabs/unify/db/schema.clj
+++ b/src/com/vendekagonlabs/unify/db/schema.clj
@@ -143,3 +143,12 @@
         (filter :unify.schema/version)
         (first)
         (:unify.schema/version))))
+
+(defn copy-schema-dir!
+  "Copies the Unify managed schema files from one directory to another.
+  Used by prepare, to save a reference schema in a working directory."
+  [src-dir dest-dir]
+  (util.io/mkdirs! dest-dir)
+  (doseq [schema-file ["schema.edn" "metamodel.edn" "enums.edn"]]
+    (io/copy (io/file src-dir schema-file)
+             (io/file dest-dir schema-file))))

--- a/src/com/vendekagonlabs/unify/import/engine.clj
+++ b/src/com/vendekagonlabs/unify/import/engine.clj
@@ -356,13 +356,13 @@
       results)
     (catch Exception e
       (let [data (ex-data e)
-            unifyty-data (text/->pretty-string data)
+            pretty-data (text/->pretty-string data)
             err-fname "PRET_ERROR_DUMP"]
         (log/error "Engine encountered exception while generating entity data, error state in file: "
                    err-fname)
         (io/write-edn-file err-fname
                            (str "Error Message:\n" (.getMessage e)
-                                "\n\nException Information:\n" unifyty-data
+                                "\n\nException Information:\n" pretty-data
                                 "\nException Stack Trace:\n  - " (text/stacktrace->string e)))
         (throw e)))))
 

--- a/src/com/vendekagonlabs/unify/import/engine/parse/matrix.clj
+++ b/src/com/vendekagonlabs/unify/import/engine/parse/matrix.clj
@@ -51,7 +51,7 @@
                                   :data-type  db-value-type
                                   :sparse?    true}
                                  ;; when not sparse, add column-attribute/target
-                                 ;; for dense matrix column interunifyation
+                                 ;; for dense matrix column interpretation
                                  (when (not= :unify.matrix.format/sparse format)
                                    {:sparse? false
                                     :target  column-attribute})))

--- a/src/com/vendekagonlabs/unify/import/file_conventions.clj
+++ b/src/com/vendekagonlabs/unify/import/file_conventions.clj
@@ -69,6 +69,12 @@
   [target-dir]
   (str (tx-data-folder target-dir) sep "diff"))
 
+(defn working-dir-schema-dir
+  "Returns the folder path for the schema-dir cached in the working
+  directory."
+  [target-dir]
+  (str target-dir sep "schema"))
+
 (defn diff-tx-dir [target-dir]
   (let [f (str target-dir sep "tx-data" sep "diff" sep "tx-data")]
     (pio/mkdirs! f)

--- a/src/com/vendekagonlabs/unify/util/io.clj
+++ b/src/com/vendekagonlabs/unify/util/io.clj
@@ -60,7 +60,7 @@
 
 (defn write-edn-file
   "Makes parent folders (if necessary) and spits directly into f is data is a string, otherwise writes
-   ->unifyty-string of data."
+   ->pretty-string of data."
   [f data]
   (make-parents f)
   (spit f (if (string? data)
@@ -124,7 +124,7 @@
 
 (defn local-tar-name
   "Vets and returns a valid 'local' tar name. Specifically translates any
-   ':' symbols into '-' because the ':' is interunifyed by tar to be a remote
+   ':' symbols into '-' because the ':' is interpreted by tar to be a remote
    file which causes local untar! to fail during an import."
   [target-name]
   (s/replace target-name #":" "-"))

--- a/src/com/vendekagonlabs/unify/util/text.clj
+++ b/src/com/vendekagonlabs/unify/util/text.clj
@@ -24,7 +24,7 @@
        (str/starts-with? (namespace x) ns)))
 
 (defn ->pretty-string
-  "Returns a unifyty string of x."
+  "Returns a pretty string of x."
   [x]
   (with-out-str (pprint x)))
 


### PR DESCRIPTION
When the schema-directory argument was added to request-db and prepare tasks to make unify's use of schema more generic, as an unintended side effect, transact also required the schema-directory to compare schema versions with the database prior to running transact. This wasn't planned or right semantically, and now transact uses a schema directory added as a subdirectory to the working directory during prepare to make this comparison instead.

This resolves #21 