### PR TITLE
Switch to official postgres container, drop postgis support

### DIFF
--- a/ops/local/docker-compose.yml
+++ b/ops/local/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   postgres:
-    image: postgis/postgis:16-3.4
+    image: postgres:16.2
     environment:
       POSTGRES_USER: unify
       POSTGRES_PASSWORD: unify


### PR DESCRIPTION
This fixes #37 

Note: users upgrading across Unify versions will need to follow the instructions at #37 to update the postgis database backing the local Datomic.