### PR TITLE
Schema cross-compilation and inference

### DIFF
--- a/src/com/vendekagonlabs/unify/db/schema/compile.clj
+++ b/src/com/vendekagonlabs/unify/db/schema/compile.clj
@@ -260,7 +260,6 @@
 
 (defn resolve-attr-type
   [schema attr]
-  (prn :attr attr)
   (cond
     (enum? schema attr)
     {:enum-of (find-enums schema attr)}

--- a/src/com/vendekagonlabs/unify/db/schema/compile/metaschema.clj
+++ b/src/com/vendekagonlabs/unify/db/schema/compile/metaschema.clj
@@ -1,0 +1,70 @@
+(ns com.vendekagonlabs.unify.db.schema.compile.metaschema
+  (:require [clojure.spec.alpha :as s]
+            [com.vendekagonlabs.unify.db.schema :as schema]))
+
+(defn unify-error-kw? [kw]
+  (= "unify.error" (namespace kw)))
+
+(defn ns-keyword? [kw]
+  (and (keyword? kw)
+       (namespace kw)))
+
+(s/def ::unify-error-tuple
+  (s/cat :error-kw unify-error-kw?
+         :error-ref some?))
+
+(s/def ::member-attribute
+  (s/or :ns-keyword ns-keyword?
+        :error ::unify-error-tuple))
+
+;; note, can make opts-map match grammar if we ever generate anything
+;; nontrivial here.
+(s/def ::opts-map map?)
+
+(s/def ::tables
+  (s/map-of ::member-attribute ::opts-map))
+
+(s/def ::joins
+  (s/map-of ns-keyword? symbol?))
+
+(s/def ::datomic-metaschema
+  (s/keys :req-un [::tables
+                   ::joins]))
+
+(defn schema->tables
+  [schema]
+  (->> schema
+       (first)
+       :index/kinds
+       (mapv (fn [[kind {:keys [unify.kind/need-uid
+                                unify.kind/global-id]}]]
+               (if-let [id (or need-uid global-id)]
+                 [(:db/ident id) {}]
+                 [[:unify.error/no-unique-id kind] {}])))
+       (into {})))
+
+(defn schema->joins
+  [schema]
+  (->> schema
+       (rest)
+       (keep (fn [{:keys [unify.ref/to
+                          db/ident]}]
+               (when (and ident to)
+                 [ident (-> to name symbol)])))
+       (into {})))
+
+
+(defn generate
+  ([schema]
+   {:tables (schema->tables schema)
+    :joins (schema->joins schema)})
+  ([]
+   (let [schema (schema/get-metamodel-and-schema)]
+     (generate schema))))
+
+(comment
+  (require '[clojure.pprint :as pp])
+  (def metaschema-ex (generate))
+  (pp/pprint metaschema-ex)
+  (s/valid? ::datomic-metaschema metaschema-ex)
+  (s/explain ::datomic-metaschema metaschema-ex))


### PR DESCRIPTION
This resolves #41 and #42 by providing the ability to infer Datomic analytics metaschema and Unify's own schema DSL from a fully specified schema directory. Initial support is considered alpha, and these utilities make a best effort, leaving placeholder `:unify.error/` keys in output files for cases that cannot be resolved, due to violated Unify constraints/expectations, or perhaps unhandled edge cases.