### PR TITLE
Hotfix: provide temp bootstrap ref data to fix band-aided template test

### DIFF
--- a/test/com/vendekagonlabs/unify/import_test.clj
+++ b/test/com/vendekagonlabs/unify/import_test.clj
@@ -43,14 +43,7 @@
   (log/info "Initializing in-memory integration test db.")
   (db/init datomic-uri
            :schema-directory schema-directory
-           :seed-data-directory seed-data-directory)
-  ;; TODO: Temp fix for drug ordering issue with template dataset.
-  (let [conn (d/connect datomic-uri)]
-    @(d/transact conn [{:drug/preferred-name "PEMBROLIZUMAB"}])
-    @(d/transact conn [{:db/id "LDHA-protein"
-                        :protein/uniprot-name "LDHA"}
-                       {:epitope/id "LDHA"
-                        :epitope/protein "LDHA-protein"}])))
+           :seed-data-directory seed-data-directory))
 
 (defn teardown []
   (log/info "Ending integration test and deleting db.")

--- a/test/resources/systems/candel/reference-data/index.edn
+++ b/test/resources/systems/candel/reference-data/index.edn
@@ -4,11 +4,6 @@
   :files ["all-coordinates-tx-data.edn"
           "all-genes-tx-data.edn"
           "all-gene-products-tx-data.edn"]}
- {:name :drugs
-  :entity-id :drug/preferred-name
-  :count 53715
-  :proprietary true
-  :files ["all-drug-tx-data.edn"]}
  {:name :diseases
   :entity-id :meddra-disease/preferred-name
   :count 23389
@@ -16,9 +11,8 @@
   :files ["all-disease-tx-data.edn"]}
  {:name :proteins-epitopes
   :entity-id :protein/uniprot-name
-  :proprietary true  ; not really, but data not in test system, so exclude
-  :count 77807
-  :files ["all-protein-epitope-tx-data.edn"]}
+  :count 2
+  :files ["temp-proteins.edn"]}
  {:name :cell-types
   :entity-id :cell-type/co-name
   :count 2319
@@ -32,6 +26,10 @@
   :count 2482
   :proprietary true  ; not really, but data not in test system, so exclude
   :files ["all-so-sequence-features-tx-data.edn"]}
+ {:name :drugs
+  :entity-id :drug/preferred-name
+  :count 1
+  :files ["temp-drugs.edn"]}
  {:name :nanostring-signatures
   :entity-id :nanostring-signature/name
   :count 42

--- a/test/resources/systems/candel/reference-data/temp-drugs.edn
+++ b/test/resources/systems/candel/reference-data/temp-drugs.edn
@@ -1,0 +1,1 @@
+[{:drug/preferred-name "PEMBROLIZUMAB"}]

--- a/test/resources/systems/candel/reference-data/temp-proteins.edn
+++ b/test/resources/systems/candel/reference-data/temp-proteins.edn
@@ -1,0 +1,5 @@
+[{:db/id "LDHA-db-id"
+  :protein/preferred-name "LDHA"
+  :protein/gene [:gene/hgnc-symbol "LDHA"]}
+ {:epitope/id "LDHA"
+  :epitope/protein "LDHA-db-id"}]


### PR DESCRIPTION
Fixes missing reference data in the test systems data  in the template-dataset in the reference CANDEL system. Does not impact functionality of Unify releases.