### PR TITLE
Restore protein functionality to templates

### DIFF
--- a/test/com/vendekagonlabs/unify/import_test.clj
+++ b/test/com/vendekagonlabs/unify/import_test.clj
@@ -65,7 +65,7 @@
       ;        aren't part of the contract, but e.g. 50 samples should be imported by this import
       ;        would be a fair stipulation of the contract implied by a unify import.
       (testing "Right number of txes completed. This implicitly also tests for data import failures."
-        (is (=  2535 (get-in import-result [:results :completed]))))
+        (is (=  2600 (get-in import-result [:results :completed]))))
       (testing "No reference data import errors."
         (is (not (seq (:errors import-result)))))
       (println "NOTE: currently skipping validation tests.")

--- a/test/resources/systems/candel/parse-config-examples/template-config.yaml
+++ b/test/resources/systems/candel/parse-config-examples/template-config.yaml
@@ -57,6 +57,65 @@ dataset:
             - unify/input-tsv-file: "processed/tcr_clonality.txt"
               sample: "sample"
               tcr-clonality: "Clonality"
+    - name: "CyTOF"
+      technology: ":assay.technology/mass-cytometry"
+      description: "CyTOF analysis performed at Primity Bio"
+      measurement-sets:
+        - name: "Spitzer gated"
+          cell-populations:
+            - unify/input-tsv-file: "processed/cell_populations_Spitzer.txt"
+              unify/na: "NA"
+              cell-type: "cell.type"
+              unify/constants:
+                from-clustering: false
+              positive-markers:
+                unify/many-delimiter: ","
+                unify/many-variable: "positive.epitopes"
+              name: "name"
+          measurements:
+            - unify/input-tsv-file: "processed/cytof_measurements_eventCount_Spitzer.txt"
+              unify/na:  "NA"
+              unify/omit-if-na:
+                - ":measurement/cell-count"
+                - ":measurement/leukocyte-count"
+                - ":measurement/percent-of-leukocytes"
+              sample: "sample"
+              cell-population: uniquePopulationName
+              unify/variable: variable
+              unify/value: value
+              unify/variables:
+                eventCount: "measurement/cell-count"
+                normalization.measurement: "measurement/leukocyte-count"
+                normalized.measurement: "measurement/percent-of-leukocytes"
+            - unify/input-tsv-file: "processed/cytof_measurements_median_Spitzer.txt"
+              unify/na: "NA"
+              unify/omit-if-na:
+                - ":measurement/median-channel-value"
+              sample: "sample"
+              cell-population: "uniquePopulationName"
+              epitope: epitope
+              median-channel-value: median
+        - name: "Spitzer clustered"
+          description: "All data pooled together and clustered with grappolo"
+          cell-populations:
+            - unify/input-tsv-file: "processed/cell_populations_cluster_Spitzer.txt"
+              name: cluster.id
+              unify/constants:
+                from-clustering: true
+          measurements:
+            - unify/input-tsv-file: "processed/cytof_measurements_clusters_Spitzer.txt"
+              unify/na: "NA"
+              unify/omit-if-na:
+                - ":measurement/median-channel-value"
+                - ":measurement/percent-of-leukocytes"
+              sample: "sample"
+              cell-population: "cluster.id"
+              epitope: "epitope"
+              unify/variable: variable
+              unify/value: value
+              unify/variables:
+                median-channel-value: "measurement/median-channel-value"
+                popsize: "measurement/percent-of-leukocytes"
   clinical-observation-sets:
     - name: "recist-and-dcb-all-timepoints"
       clinical-observations:

--- a/test/resources/systems/candel/reference-data/index.edn
+++ b/test/resources/systems/candel/reference-data/index.edn
@@ -11,8 +11,8 @@
   :files ["all-disease-tx-data.edn"]}
  {:name :proteins-epitopes
   :entity-id :protein/uniprot-name
-  :count 2
-  :files ["temp-proteins.edn"]}
+  :count 77807
+  :files ["all-protein-epitope-tx-data.edn"]}
  {:name :cell-types
   :entity-id :cell-type/co-name
   :count 2319
@@ -24,7 +24,6 @@
  {:name :so-sequence-features
   :entity-id :so-sequence-feature/name
   :count 2482
-  :proprietary true  ; not really, but data not in test system, so exclude
   :files ["all-so-sequence-features-tx-data.edn"]}
  {:name :drugs
   :entity-id :drug/preferred-name

--- a/test/resources/systems/candel/template-dataset/config.edn
+++ b/test/resources/systems/candel/template-dataset/config.edn
@@ -124,63 +124,54 @@
                                                                                        :tcr-clonality    "Clonality"}]}]}
 
                                                   ; Below is an example of how we represent cytometry data, including defining cell populations both from gating and clustering
-                                                  #_{:name             "CyTOF"
-                                                     :technology       :assay.technology/mass-cytometry
-                                                     :description      "CyTOF analysis performed at Primity Bio"
-                                                     :measurement-sets [{:name             "Spitzer gated"
-                                                                         :cell-populations [{:unify/input-tsv-file "processed/cell_populations_Spitzer.txt"
-                                                                                             :unify/na         "NA"
-                                                                                             :cell-type        "cell.type"
-                                                                                             :unify/constants  {:from-clustering false}
-                                                                                             :positive-markers {:unify/many-delimiter ","
-                                                                                                                :unify/many-variable  "positive.epitopes"}
-                                                                                             :name             "name"}]
-                                                                         :measurements     [{:unify/input-tsv-file "processed/cytof_measurements_eventCount_Spitzer.txt"
-                                                                                             :unify/na         "NA"
-                                                                                             :unify/omit-if-na [:measurement/cell-count
-                                                                                                                :measurement/leukocyte-count
-                                                                                                                :measurement/percent-of-leukocytes]
-                                                                                             :sample           "sample"
-                                                                                             :cell-population  "uniquePopulationName"
-                                                                                             :unify/variable   "variable"
-                                                                                             :unify/value      "value"
-                                                                                             :unify/variables  {"eventCount"                :measurement/cell-count
-                                                                                                                "normalization.measurement" :measurement/leukocyte-count
-                                                                                                                "normalized.measurement"    :measurement/percent-of-leukocytes}}
-                                                                                            {:unify/input-tsv-file     "processed/cytof_measurements_median_Spitzer.txt"
-                                                                                             :unify/na             "NA"
-                                                                                             :unify/omit-if-na     [:measurement/median-channel-value]
-                                                                                             :sample               "sample"
-                                                                                             :cell-population      "uniquePopulationName"
-                                                                                             :epitope              "epitope"
-                                                                                             :median-channel-value "median"}]}
+                                                  {:name             "CyTOF"
+                                                   :technology       :assay.technology/mass-cytometry
+                                                   :description      "CyTOF analysis performed at Primity Bio"
+                                                   :measurement-sets [{:name             "Spitzer gated"
+                                                                       :cell-populations [{:unify/input-tsv-file "processed/cell_populations_Spitzer.txt"
+                                                                                           :unify/na         "NA"
+                                                                                           :cell-type        "cell.type"
+                                                                                           :unify/constants  {:from-clustering false}
+                                                                                           :positive-markers {:unify/many-delimiter ","
+                                                                                                              :unify/many-variable  "positive.epitopes"}
+                                                                                           :name             "name"}]
+                                                                       :measurements     [{:unify/input-tsv-file "processed/cytof_measurements_eventCount_Spitzer.txt"
+                                                                                           :unify/na         "NA"
+                                                                                           :unify/omit-if-na [:measurement/cell-count
+                                                                                                              :measurement/leukocyte-count
+                                                                                                              :measurement/percent-of-leukocytes]
+                                                                                           :sample           "sample"
+                                                                                           :cell-population  "uniquePopulationName"
+                                                                                           :unify/variable   "variable"
+                                                                                           :unify/value      "value"
+                                                                                           :unify/variables  {"eventCount"                :measurement/cell-count
+                                                                                                              "normalization.measurement" :measurement/leukocyte-count
+                                                                                                              "normalized.measurement"    :measurement/percent-of-leukocytes}}
+                                                                                          {:unify/input-tsv-file     "processed/cytof_measurements_median_Spitzer.txt"
+                                                                                           :unify/na             "NA"
+                                                                                           :unify/omit-if-na     [:measurement/median-channel-value]
+                                                                                           :sample               "sample"
+                                                                                           :cell-population      "uniquePopulationName"
+                                                                                           :epitope              "epitope"
+                                                                                           :median-channel-value "median"}]}
 
 
-                                                                        {:name             "Spitzer clustered"
-                                                                         :description      "All data pooled together and clustered with grappolo"
-                                                                         :cell-populations [{:unify/input-tsv-file "processed/cell_populations_cluster_Spitzer.txt"
-                                                                                             :name             "cluster.id"
-                                                                                             :unify/constants  {:from-clustering true}}]
-                                                                         :measurements     [{:unify/input-tsv-file "processed/cytof_measurements_clusters_Spitzer.txt"
-                                                                                             :unify/na         "NA"
-                                                                                             :unify/omit-if-na [:measurement/median-channel-value
-                                                                                                                :measurement/percent-of-leukocytes]
-                                                                                             :sample           "sample"
-                                                                                             :cell-population  "cluster.id"
-                                                                                             :epitope          "epitope"
-                                                                                             :unify/variable   "variable"
-                                                                                             :unify/value      "value"
-                                                                                             :unify/variables  {"median-channel-value" :measurement/median-channel-value
-                                                                                                                "popsize"              :measurement/percent-of-leukocytes}}]}]}]
-
-
-
-
-
-
-
-
-
+                                                                      {:name             "Spitzer clustered"
+                                                                       :description      "All data pooled together and clustered with grappolo"
+                                                                       :cell-populations [{:unify/input-tsv-file "processed/cell_populations_cluster_Spitzer.txt"
+                                                                                           :name             "cluster.id"
+                                                                                           :unify/constants  {:from-clustering true}}]
+                                                                       :measurements     [{:unify/input-tsv-file "processed/cytof_measurements_clusters_Spitzer.txt"
+                                                                                           :unify/na         "NA"
+                                                                                           :unify/omit-if-na [:measurement/median-channel-value
+                                                                                                              :measurement/percent-of-leukocytes]
+                                                                                           :sample           "sample"
+                                                                                           :cell-population  "cluster.id"
+                                                                                           :epitope          "epitope"
+                                                                                           :unify/variable   "variable"
+                                                                                           :unify/value      "value"
+                                                                                           :unify/variables  {"median-channel-value" :measurement/median-channel-value
+                                                                                                              "popsize"              :measurement/percent-of-leukocytes}}]}]}]
 
 
                       ; We are now out of the :dataset/assays section of the map and back to the top level of the dataset map
@@ -393,11 +384,6 @@
                       ; values all in one column, with values separated by a delimeter like a semicolon, and use the following syntax to specify that
                       :genes               {:unify/many-delimiter ";"
                                             :unify/many-variable  "Genes"}}
- ;; TODO: uncomment out when ref ordering bug fixed
- ;; If you haven't installed a proprietary WHO Drug reference dataset, you can
- ;; define all drug names referred to in treatment data here.
- #_:drug            #_[{:unify/input-tsv-file "processed/drugs.tsv"
-                        :preferred-name   "name"}]
  :clinical-trial     {:nct-number "NCT01295827"
                       :other-ids  "KEYNOTE-001"
                       :name-long  "Study of Pembrolizumab (MK-3475) in Participants With Progressive Locally Advanced or Metastatic Carcinoma, Melanoma, or Non-small Cell Lung Carcinoma"}}

--- a/test/resources/systems/candel/template-dataset/config.yaml
+++ b/test/resources/systems/candel/template-dataset/config.yaml
@@ -1,7 +1,8 @@
+# $schema: ./import-config-schema.json
 unify/import:
   name: "template-import"
-  user: "your-user-name"
-  mappings: "mappings.yaml"
+  user: "your-user-name@your-organization.org"
+  mappings: "mappings.edn"
 dataset:
   description: "Description of your dataset, ie title of paper, title of clinical trial, or description of conglomerate dataset"
   name: "template-dataset-10"
@@ -29,14 +30,14 @@ dataset:
       measurement-sets:
         - name: "clinical LDH measurements"
           measurements:
-            unify/input-tsv-file: "processed/ldh_meas_and_samples.txt"
-            unify/na: "NA"
-            unify/omit-if-na:
-              - ":measurement/ng-mL"
-            sample: "sample.id"
-            measurement/ng-mL: "LDH @ Baseline"
-            unify/constants:
-              measurement/epitope: "LDHA"
+            - unify/input-tsv-file: "processed/ldh_meas_and_samples.txt"
+              unify/na: "NA"
+              unify/omit-if-na:
+                - ":measurement/ng-mL"
+              sample: "sample.id"
+              measurement/ng-mL: "LDH @ Baseline"
+              unify/constants:
+                measurement/epitope: "LDHA"
     - name: "nanostring"
       technology: :assay.technology/nanostring
       description: "gene expr via nanostring"
@@ -56,6 +57,65 @@ dataset:
             - unify/input-tsv-file: "processed/tcr_clonality.txt"
               sample: "sample"
               tcr-clonality: "Clonality"
+    - name: "CyTOF"
+      technology: ":assay.technology/mass-cytometry"
+      description: "CyTOF analysis performed at Primity Bio"
+      measurement-sets:
+        - name: "Spitzer gated"
+          cell-populations:
+            - unify/input-tsv-file: "processed/cell_populations_Spitzer.txt"
+              unify/na: "NA"
+              cell-type: "cell.type"
+              unify/constants:
+                from-clustering: false
+              positive-markers:
+                unify/many-delimiter: ","
+                unify/many-variable: "positive.epitopes"
+              name: "name"
+          measurements:
+            - unify/input-tsv-file: "processed/cytof_measurements_eventCount_Spitzer.txt"
+              unify/na:  "NA"
+              unify/omit-if-na:
+                - ":measurement/cell-count"
+                - ":measurement/leukocyte-count"
+                - ":measurement/percent-of-leukocytes"
+              sample: "sample"
+              cell-population: uniquePopulationName
+              unify/variable: variable
+              unify/value: value
+              unify/variables:
+                eventCount: "measurement/cell-count"
+                normalization.measurement: "measurement/leukocyte-count"
+                normalized.measurement: "measurement/percent-of-leukocytes"
+            - unify/input-tsv-file: "processed/cytof_measurements_median_Spitzer.txt"
+              unify/na: "NA"
+              unify/omit-if-na:
+                - ":measurement/median-channel-value"
+              sample: "sample"
+              cell-population: "uniquePopulationName"
+              epitope: epitope
+              median-channel-value: median
+        - name: "Spitzer clustered"
+          description: "All data pooled together and clustered with grappolo"
+          cell-populations:
+            - unify/input-tsv-file: "processed/cell_populations_cluster_Spitzer.txt"
+              name: cluster.id
+              unify/constants:
+                from-clustering: true
+          measurements:
+            - unify/input-tsv-file: "processed/cytof_measurements_clusters_Spitzer.txt"
+              unify/na: "NA"
+              unify/omit-if-na:
+                - ":measurement/median-channel-value"
+                - ":measurement/percent-of-leukocytes"
+              sample: "sample"
+              cell-population: "cluster.id"
+              epitope: "epitope"
+              unify/variable: variable
+              unify/value: value
+              unify/variables:
+                median-channel-value: "measurement/median-channel-value"
+                popsize: "measurement/percent-of-leukocytes"
   clinical-observation-sets:
     - name: "recist-and-dcb-all-timepoints"
       clinical-observations:
@@ -71,6 +131,10 @@ dataset:
     - HLA-A-type:
         unify/many-variable: "hlaA"
         unify/many-delimiter: ","
+      # TODO: Unify should treat an object or an array here equivalently, so we should probably
+      # modify JSON spec at some point. But on the flip side, there appears to be a bug in
+      # config parsing when this is an array with one object instead of an isolated object, so
+      # we should wait to address that. Removed out of PR #53 and into a new issue.
       therapies:
         unify/input-csv-file: "processed/rizvi-therapies.txt"
         treatment-regimen: "regimen"
@@ -144,14 +208,14 @@ dataset:
       clinical-trial:
         nct-number: "NCT01295827"
       drug-regimens:
-        drug: "PEMBROLIZUMAB"
-        cycle-length: 21
+        - drug: "PEMBROLIZUMAB"
+          cycle-length: 21
     - name: "Pembrolizumab-2wk"
       clinical-trial:
         nct-number: "NCT01295827"
       drug-regimens:
-        drug: "PEMBROLIZUMAB"
-        cycle-length: 14
+        - drug: "PEMBROLIZUMAB"
+          cycle-length: 14
 genomic-coordinate:
   - unify/input-tsv-file: "processed/genomic_coords.txt"
     contig: "chrom"


### PR DESCRIPTION
This fixes missing reference data from proteins for the template/candel/UnifyBio test cases, improving coverage of functionality for tests and guarantees for those dependent systems.