### PR TITLE
Add epitope ref data to template dataset tests

### DIFF
--- a/test/com/vendekagonlabs/unify/import_test.clj
+++ b/test/com/vendekagonlabs/unify/import_test.clj
@@ -65,7 +65,7 @@
       ;        aren't part of the contract, but e.g. 50 samples should be imported by this import
       ;        would be a fair stipulation of the contract implied by a unify import.
       (testing "Right number of txes completed. This implicitly also tests for data import failures."
-        (is (=  2600 (get-in import-result [:results :completed]))))
+        (is (=  2601 (get-in import-result [:results :completed]))))
       (testing "No reference data import errors."
         (is (not (seq (:errors import-result)))))
       (println "NOTE: currently skipping validation tests.")

--- a/test/resources/systems/candel/parse-config-examples/template-config.yaml
+++ b/test/resources/systems/candel/parse-config-examples/template-config.yaml
@@ -282,6 +282,12 @@ cnv:
   genes:
     unify/many-delimiter: ";"
     unify/many-variable: "Genes"
+epitope:
+  unify/input-tsv-file: "processed/epitopes.tsv"
+  id: "id"
+  protein:
+    unify/many-variable: "proteins"
+    unify/many-delimiter: ";"
 clinical-trial:
   nct-number: "NCT01295827"
   other-ids: "KEYNOTE-001"

--- a/test/resources/systems/candel/template-dataset/config.edn
+++ b/test/resources/systems/candel/template-dataset/config.edn
@@ -384,6 +384,10 @@
                       ; values all in one column, with values separated by a delimeter like a semicolon, and use the following syntax to specify that
                       :genes               {:unify/many-delimiter ";"
                                             :unify/many-variable  "Genes"}}
+ :epitope            {:unify/input-tsv-file "processed/epitopes.tsv"
+                      :id "id"
+                      :protein {:unify/many-delimiter ";"
+                                :unify/many-variable "proteins"}}
  :clinical-trial     {:nct-number "NCT01295827"
                       :other-ids  "KEYNOTE-001"
                       :name-long  "Study of Pembrolizumab (MK-3475) in Participants With Progressive Locally Advanced or Metastatic Carcinoma, Melanoma, or Non-small Cell Lung Carcinoma"}}

--- a/test/resources/systems/candel/template-dataset/processed/cell_populations_Spitzer.txt
+++ b/test/resources/systems/candel/template-dataset/processed/cell_populations_Spitzer.txt
@@ -52,7 +52,7 @@ Treg > Ki67+CD38+	CD4-positive, CD25-positive, alpha-beta regulatory T cell	KI67
 Treg > Ki67+HLADR+	CD4-positive, CD25-positive, alpha-beta regulatory T cell	KI67,DRA
 Treg > Ki67+Tbet+	CD4-positive, CD25-positive, alpha-beta regulatory T cell	KI67,DRA
 Treg > Tbet+	CD4-positive, CD25-positive, alpha-beta regulatory T cell	TBX21
-CD8  T Cells	CD8-positive, alpha-beta T cell	NA
+CD8  T Cells	CD8-positive, alpha-beta T cell	CD8
 CD8  T Cells > CD25+	CD8-positive, alpha-beta T cell	IL2RA
 CD8  T Cells > CD38+	CD8-positive, alpha-beta T cell	CD38
 CD8  T Cells > Ki-67+	CD8-positive, alpha-beta T cell	KI67
@@ -63,7 +63,7 @@ CD8  T Cells > Ki67+CD38+	CD8-positive, alpha-beta T cell	KI67,CD38
 CD8  T Cells > Ki67+HLADR+	CD8-positive, alpha-beta T cell	KI67,DRA
 CD8  T Cells > Ki67+Tbet+	CD8-positive, alpha-beta T cell	KI67,DRA
 CD8  T Cells > Tbet+	CD8-positive, alpha-beta T cell	TBX21
-CM CD8	central memory CD8-positive, alpha-beta T cell	NA
+CM CD8	central memory CD8-positive, alpha-beta T cell	CD8
 CM CD8 > CD25+	central memory CD8-positive, alpha-beta T cell	IL2RA
 CM CD8 > CD38+	central memory CD8-positive, alpha-beta T cell	CD38
 CM CD8 > Ki-67+	central memory CD8-positive, alpha-beta T cell	KI67

--- a/test/resources/systems/candel/template-dataset/processed/epitopes.tsv
+++ b/test/resources/systems/candel/template-dataset/processed/epitopes.tsv
@@ -1,0 +1,2 @@
+id	proteins
+CD8	CD8A;CD8B


### PR DESCRIPTION
No issues with epitope import were uncovered during this test, so this PR mostly functions to strengthen guarantees/guard against regressions here.