### PR TITLE
Parse yaml config bugfixes

### DIFF
--- a/src/com/vendekagonlabs/unify/import/engine/parse/config.clj
+++ b/src/com/vendekagonlabs/unify/import/engine/parse/config.clj
@@ -499,18 +499,18 @@
   [cfg-dir m]
   (let [all-maps-list (concat (coll/all-nested-maps m :unify/input-tsv-file)
                               (coll/all-nested-maps m :unify/input-csv-file))
-        ;; TODO: conditional is gnarly,
-        nested-directive? (fn [[_ v]]
-                            (if (and (map? v)
-                                     (or (:unify/input-tsv-file v)
-                                         (:unify/input-csv-file v)))
-                              true
-                              (if (sequential? v)
-                                (let [maybe-first-map (first v)]
-                                  (and (map? maybe-first-map)
-                                       (or (:unify/input-tsv-file maybe-first-map)
-                                           (:unify/input-csv-file maybe-first-map))))
-                                false)))]
+        nested-directive? (fn [[k v]]
+                            (when-not (and
+                                        (namespace k)
+                                        (str/starts-with? (namespace k) "unify"))
+                              (let [check-map (if (map? v)
+                                                v
+                                                (when (sequential? v)
+                                                  (when (map? (first v))
+                                                    (first v))))]
+                                (when check-map
+                                  (or (:unify/input-csv-file check-map)
+                                      (:unify/input-tsv-file check-map))))))]
     (->> all-maps-list
          (map #(into {} (remove nested-directive? %)))
          ;; if we have multiple files from parsed glob pattern, then we

--- a/src/com/vendekagonlabs/unify/import/engine/parse/config.clj
+++ b/src/com/vendekagonlabs/unify/import/engine/parse/config.clj
@@ -499,8 +499,18 @@
   [cfg-dir m]
   (let [all-maps-list (concat (coll/all-nested-maps m :unify/input-tsv-file)
                               (coll/all-nested-maps m :unify/input-csv-file))
-        nested-directive? (fn [[_ v]] (and (map? v) (or (:unify/input-tsv-file v)
-                                                        (:unify/input-csv-file v))))]
+        ;; TODO: conditional is gnarly,
+        nested-directive? (fn [[_ v]]
+                            (if (and (map? v)
+                                     (or (:unify/input-tsv-file v)
+                                         (:unify/input-csv-file v)))
+                              true
+                              (if (sequential? v)
+                                (let [maybe-first-map (first v)]
+                                  (and (map? maybe-first-map)
+                                       (or (:unify/input-tsv-file maybe-first-map)
+                                           (:unify/input-csv-file maybe-first-map))))
+                                false)))]
     (->> all-maps-list
          (map #(into {} (remove nested-directive? %)))
          ;; if we have multiple files from parsed glob pattern, then we

--- a/test/com/vendekagonlabs/unify/import/engine/parse/config/yaml_test.clj
+++ b/test/com/vendekagonlabs/unify/import/engine/parse/config/yaml_test.clj
@@ -14,6 +14,11 @@
 (def ref-mapping-edn-file
   "test/resources/systems/candel/template-dataset/mappings.edn")
 
+(def matrix-config-yaml
+  "test/resources/systems/candel/matrix/config.yaml")
+(def matrix-ref-config-edn
+  "test/resources/systems/candel/matrix/config.edn")
+
 (deftest equivalent-config-test
   (let [parsed-yaml-config (sut/read-config-file config-yaml-file)
         parsed-edn-config (util.io/read-edn-file ref-config-edn-file)
@@ -28,6 +33,17 @@
 (deftest equivalent-mapping-test
   (let [parsed-yaml-mapping (sut/read-mappings-file mapping-yaml-file)
         parsed-edn-mapping (util.io/read-edn-file ref-mapping-edn-file)
+        diff (data/diff parsed-edn-mapping parsed-yaml-mapping)]
+    (testing "YAML and edn equivalent configs parse to equivalent edn data structures."
+      (is (= parsed-edn-mapping parsed-yaml-mapping))
+      ;; one of these will always fail when equality fails, this will cause failure
+      ;; report to show the diff data structure for what's not equivalent
+      (is (nil? (first diff)))
+      (is (nil? (second diff))))))
+
+(deftest equivalent-matrix-config-test
+  (let [parsed-yaml-mapping (sut/read-config-file matrix-config-yaml)
+        parsed-edn-mapping (util.io/read-edn-file matrix-ref-config-edn)
         diff (data/diff parsed-edn-mapping parsed-yaml-mapping)]
     (testing "YAML and edn equivalent configs parse to equivalent edn data structures."
       (is (= parsed-edn-mapping parsed-yaml-mapping))

--- a/test/resources/systems/candel/matrix/config.yaml
+++ b/test/resources/systems/candel/matrix/config.yaml
@@ -1,0 +1,53 @@
+unify/import:
+  user: "test-user"
+  mappings: "mappings.edn"
+  name: "matrix-import"
+
+dataset:
+  name: "matrix-test"
+  assays:
+    - name: "rna-seq"
+      technology: ":assay.technology/RNA-seq"
+      measurement-sets:
+        - name: "rna seq data"
+          single-cells:
+            - unify/input-tsv-file: "cell-barcodes.tsv"
+              id: "barcode"
+          measurement-matrices:
+            - name: "screening-rna-seq"
+              measurement-type: ":measurement/read-count"
+              unify.matrix/input-file: "dense-rnaseq-fixed.tsv"
+              unify.matrix/format: ":unify.matrix.format/dense"
+              unify.matrix/column-attribute: ":measurement-matrix/gene-products"
+              unify.matrix/indexed-by:
+                sample.id: ":measurement-matrix/samples"
+            - name: "single cell counts"
+              measurement-type: ":measurement/read-count"
+              unify.matrix/constants:
+                measurement-matrix/samples: "SYNTH-SC-DATA-01"
+              unify.matrix/input-file: "short-processed-counts-fixed.tsv"
+              unify.matrix/format: ":unify.matrix.format/sparse"
+              unify.matrix/indexed-by:
+                barcode: ":measurement-matrix/single-cells"
+                hugo: ":measurement-matrix/gene-products"
+
+  subjects:
+    - unify/input-tsv-file: "samples.tsv"
+      id: "subj.ids"
+      sex: "sex"
+      race: "race"
+      ethnicity: "ethnic"
+
+  samples:
+    - unify/input-tsv-file: "samples.tsv"
+      id: "samples"
+      subject: "subj.ids"
+      unify/constants:
+        timepoint: "screening"
+    - id: "SYNTH-SC-DATA-01"
+      subject: "SUBJ8"
+      timepoint: "screening"
+
+  timepoints:
+    - id: "screening"
+      type: ":timepoint.type/baseline"

--- a/test/resources/systems/candel/parse-config-examples/template-config.yaml
+++ b/test/resources/systems/candel/parse-config-examples/template-config.yaml
@@ -132,18 +132,17 @@ dataset:
         unify/many-variable: "hlaA"
         unify/many-delimiter: ","
       # TODO: Unify should treat an object or an array here equivalently, so we should probably
-      # modify JSON spec at some point. But on the flip side, there appears to be a bug in
-      # config parsing when this is an array with one object instead of an isolated object, so
-      # we should wait to address that. Removed out of PR #53 and into a new issue.
+      # modify JSON spec at some point. But this rule works with both literals and import jobs,
+      # so maybe ok to keep spec as is?
       therapies:
-        unify/input-csv-file: "processed/rizvi-therapies.txt"
-        treatment-regimen: "regimen"
-        line: "line"
-        unify/constants:
-          order: 1
-        unify/reverse:
-          unify/rev-variable: "subject.id"
-          unify/rev-attr: ":subject/therapies"
+        - unify/input-csv-file: "processed/rizvi-therapies.txt"
+          treatment-regimen: "regimen"
+          line: "line"
+          unify/constants:
+            order: 1
+          unify/reverse:
+            unify/rev-variable: "subject.id"
+            unify/rev-attr: ":subject/therapies"
       age: "age"
       sex: "gender"
       HLA-C-type:

--- a/test/resources/systems/candel/template-dataset/config.edn
+++ b/test/resources/systems/candel/template-dataset/config.edn
@@ -233,16 +233,16 @@
                                                    ; The following map specifies the links between subjects and their therapy or therapies. Each subject can have 0, 1, or many therapies.
                                                    ; The therapy entity links subjects to treatment-regimens (see below) which are things like arms of clinical trials, which many subjects are on.
                                                    ; The wick package contains helper functions to generate all this data for the simple case in which each subject has only a single therapy
-                                                   :therapies        {; This input file will have one line per subject-therapy combination
-                                                                      :unify/input-csv-file  "processed/rizvi-therapies.txt"
-                                                                      ; The treatment-regimen attribute points to treatment regimens, which have been separately specified in the dataset (see below)
-                                                                      ; This attribute needs to contain values that correspond to the :treatment-regimen/name fields
-                                                                      :treatment-regimen "regimen"
-                                                                      :line              "line"
-                                                                      ; We use :unify/constants here to indicate the :therapy/order attribute, which is 1 for all therapies in this particular dataset (because here each subject has only one therapy)
-                                                                      :unify/constants   {:order 1}
-                                                                      :unify/reverse     {:unify/rev-variable "subject.id"
-                                                                                          :unify/rev-attr     :subject/therapies}}}
+                                                   :therapies        [{; This input file will have one line per subject-therapy combination
+                                                                       :unify/input-csv-file  "processed/rizvi-therapies.txt"
+                                                                       ; The treatment-regimen attribute points to treatment regimens, which have been separately specified in the dataset (see below)
+                                                                       ; This attribute needs to contain values that correspond to the :treatment-regimen/name fields
+                                                                       :treatment-regimen "regimen"
+                                                                       :line              "line"
+                                                                       ; We use :unify/constants here to indicate the :therapy/order attribute, which is 1 for all therapies in this particular dataset (because here each subject has only one therapy)
+                                                                       :unify/constants   {:order 1}
+                                                                       :unify/reverse     {:unify/rev-variable "subject.id"
+                                                                                           :unify/rev-attr     :subject/therapies}}]}
 
                                                   {:unify/input-tsv-file "processed/tcga-subjects.tsv"
                                                    :unify/na         ""

--- a/test/resources/systems/candel/template-dataset/config.yaml
+++ b/test/resources/systems/candel/template-dataset/config.yaml
@@ -136,14 +136,14 @@ dataset:
       # config parsing when this is an array with one object instead of an isolated object, so
       # we should wait to address that. Removed out of PR #53 and into a new issue.
       therapies:
-        unify/input-csv-file: "processed/rizvi-therapies.txt"
-        treatment-regimen: "regimen"
-        line: "line"
-        unify/constants:
-          order: 1
-        unify/reverse:
-          unify/rev-variable: "subject.id"
-          unify/rev-attr: ":subject/therapies"
+        - unify/input-csv-file: "processed/rizvi-therapies.txt"
+          treatment-regimen: "regimen"
+          line: "line"
+          unify/constants:
+            order: 1
+          unify/reverse:
+            unify/rev-variable: "subject.id"
+            unify/rev-attr: ":subject/therapies"
       age: "age"
       sex: "gender"
       HLA-C-type:


### PR DESCRIPTION
This fixes:

- cardinality many nested attribute refs
- correct parsing for all nested directives
- unhandled `:unify.matrix/indexed-by` form in yaml parsing.

Resolves issues #73 , #74 , and #54 (overlapping issue w/ #73 )